### PR TITLE
ADU-313 - error from mismatched function declaration

### DIFF
--- a/src/Prettus/Repository/Traits/CacheableRepository.php
+++ b/src/Prettus/Repository/Traits/CacheableRepository.php
@@ -218,11 +218,12 @@ trait CacheableRepository
      *
      * @param null  $limit
      * @param array $columns
+     * @param string $method
      *
      * @return mixed
      */
-    public function paginate($limit = null, $columns = ['*'])
-    {
+    public function paginate($limit = null, $columns = ['*'], $method = 'paginate')
+     {
         if (!$this->allowedCache('paginate') || $this->isSkippedCache()) {
             return parent::paginate($limit, $columns);
         }


### PR DESCRIPTION
This change is in the upstream repository that Ian forked but as he's modified the repo locally, we're out of sync with upstream so not safe to fetch and merge from upstream. This appears to get ADU working on 7.4 though, at least "php artisan" has stopped returning fatal errors.